### PR TITLE
timer framework

### DIFF
--- a/API.md
+++ b/API.md
@@ -86,6 +86,7 @@
 - `on_metadata_inventory_put(app, mtos, player, listname, index, stack)` - Optional: custom check on items put
 - `on_metadata_inventory_take(app, mtos, player, listname, index, stack)` - Optional: custom check on items put
 - `on_metadata_inventory_move(app, mtos, player, from_list, from_index, to_list, to_index, count)` - Optional: custom check on items put
+- `on_timer(app, mtos, nil, elapsed) - Optional. The on-timer callback (no sender)
 
 `laptop.register_view(internal_shortname, { definitiontable })` - add a new app or view
 same as register_app, but the view flag is set. app_name and app_icon not necessary
@@ -94,6 +95,7 @@ same as register_app, but the view flag is set. app_name and app_icon not necess
 `local app = mtos:get_app(appname)` - Give the app object internal_shortname, connected to given mtos. Not necessary in formspec_func or receive_fields_func because given trough interface
 - `app:back_app(fields, sender)` - Go back to previous app/view. Trough fields/sender additional data can be sent to the previous app trough receive_fields_func
 - `app:exit_app()` - Delete call stack and return to launcher
+- `app:get_timer()` - Get timer for this app (based on nodetimer)
 
 
 ## Themes

--- a/app_fw.lua
+++ b/app_fw.lua
@@ -61,6 +61,11 @@ function app_class:exit_app()
 	self.os:set_app() -- launcher
 end
 
+function app_class:get_timer()
+	self.os.timer = self.os.timer or minetest.get_node_timer(self.os.pos)
+	return self.os.timer
+end
+
 -- Register new app
 function laptop.register_app(name, def)
 	laptop.apps[name] = def

--- a/apps/os_dialogs_app.lua
+++ b/apps/os_dialogs_app.lua
@@ -14,6 +14,9 @@ local function get_file(key, value)
 	end
 end
 
+laptop.register_view('os:power_off', {
+	fullscreen = true,
+})
 
 
 laptop.register_view('os:select_file', {

--- a/node_fw.lua
+++ b/node_fw.lua
@@ -126,6 +126,10 @@ local function on_metadata_inventory_take(pos, listname, index, stack, player)
 	local mtos = laptop.os_get(pos)
 	mtos:pass_to_app("on_metadata_inventory_take", true, player, listname, index, stack)
 end
+local function on_timer(pos, elapsed)
+	local mtos = laptop.os_get(pos)
+	mtos:pass_to_app("on_timer", true, nil, elapsed)
+end
 
 function laptop.register_hardware(name, hwdef)
 	local default_nodename = name.."_"..hwdef.sequence[1]
@@ -161,6 +165,7 @@ function laptop.register_hardware(name, hwdef)
 		def.on_metadata_inventory_move = on_metadata_inventory_move
 		def.on_metadata_inventory_put = on_metadata_inventory_put
 		def.on_metadata_inventory_take = on_metadata_inventory_take
+		def.on_timer = on_timer
 		minetest.register_node(nodename, def)
 
 		-- set node configuration for hooks

--- a/node_fw.lua
+++ b/node_fw.lua
@@ -128,7 +128,7 @@ local function on_metadata_inventory_take(pos, listname, index, stack, player)
 end
 local function on_timer(pos, elapsed)
 	local mtos = laptop.os_get(pos)
-	mtos:pass_to_app("on_timer", true, nil, elapsed)
+	return mtos:pass_to_app("on_timer", true, nil, elapsed)
 end
 
 function laptop.register_hardware(name, hwdef)

--- a/os.lua
+++ b/os.lua
@@ -27,24 +27,21 @@ function os_class:power_on(new_node_name)
 	for k,v in pairs(laptop.os_get(self.pos)) do
 		self[k] = v
 	end
-	self.sysram.state = 'on'
 	self:swap_node(new_node_name)
 	self:set_app() --launcher
 end
 
 -- Power on the system / and resume last running app
 function os_class:resume(new_node_name)
+	self.sysram.current_app = self:appstack_pop()
 	self:swap_node(new_node_name)
-	self.sysram.state = 'on'
 	self:set_app(self.sysram.current_app)
 end
 
 -- Power off the system
 function os_class:power_off(new_node_name)
 	self:swap_node(new_node_name)
-	self.meta:set_string('formspec', "")
-	self.sysram.state = 'off'
-	self:save()
+	self:set_app('os:power_off')
 end
 
 -- Set infotext for system
@@ -128,7 +125,7 @@ function os_class:pass_to_app(method, reshow, sender, ...)
 	local app = self:get_app(appname)
 	local ret = app:receive_data(method, reshow, sender, ...)
 	self.sysram.last_player = sender:get_player_name()
-	if self.sysram.current_app == appname and reshow and self.sysram.state == 'on' then
+	if self.sysram.current_app == appname and reshow then
 		local formspec = app:get_formspec()
 		if formspec ~= false then
 			self.meta:set_string('formspec', formspec)

--- a/os.lua
+++ b/os.lua
@@ -110,6 +110,29 @@ function os_class:set_app(appname)
 			self.sysram.current_app ~= newapp then
 		self:appstack_add(self.sysram.current_app)
 	end
+
+	-- suspend timer from previous app and resume the new one
+	if self.sysram.current_app ~= newapp then
+		self.timer = minetest.get_node_timer(self.pos)
+		if self.sysram.current_app then
+			if self.timer:is_started() then
+				self.sysram.app_timer[self.sysram.current_app] = {
+						timeout = self.timer:get_timeout(),
+						elapsed = self.timer:get_elapsed(),
+					}
+			else
+				self.sysram.app_timer[self.sysram.current_app] = nil
+			end
+		end
+		-- restore the timer of current app
+		if self.sysram.app_timer[newapp] then
+			local data = self.sysram.app_timer[newapp]
+			self.timer:set(data.timeout, data.elapsed)
+		else
+			self.timer:stop()
+		end
+	end
+
 	self.sysram.current_app = newapp
 	local app = self:get_app(newapp)
 	local formspec = app:get_formspec()
@@ -124,7 +147,9 @@ function os_class:pass_to_app(method, reshow, sender, ...)
 	local appname = self.sysram.current_app or self.hwdef.custom_launcher or "launcher"
 	local app = self:get_app(appname)
 	local ret = app:receive_data(method, reshow, sender, ...)
-	self.sysram.last_player = sender:get_player_name()
+	if sender then
+		self.sysram.last_player = sender:get_player_name()
+	end
 	if self.sysram.current_app == appname and reshow then
 		local formspec = app:get_formspec()
 		if formspec ~= false then
@@ -162,6 +187,7 @@ function laptop.os_get(pos)
 	self.bdev = laptop.get_bdev_handler(self)
 	self.sysram = self.bdev:get_app_storage('ram', 'os')
 	self.sysram.stack = self.sysram.stack or {}
+	self.sysram.app_timer = self.sysram.app_timer or {}
 	self.sysdata = self.bdev:get_app_storage('system', 'os')
 	self.theme = self:get_theme()
 	return self


### PR DESCRIPTION
This PR contains the support for node-timer in framework. The timer state is saved per app and restored if the app gets back active. So each app can utilize the timer independently to other apps.