### PR TITLE
TNT Sweeper Bug Fix

### DIFF
--- a/apps/TNTsweeper_app.lua
+++ b/apps/TNTsweeper_app.lua
@@ -61,6 +61,9 @@ function sweeper_class:reveal(sel_w, sel_h)
 			return true
 		end
 		self.data.open_count = self.data.open_count + 1
+		if sel.bomb_marked then
+			self.data.bomb_count = self.data.bomb_count - 1
+		end
 		if sel.count == 0 then
 			for w = sel_w - 1, sel_w + 1 do
 				for h = sel_h - 1, sel_h + 1 do


### PR DESCRIPTION
Fixes bug where clearing a non-bomb marked square doesn't lower bomb count. I kept ending small easy game with 12/10 bombs cleared.