### PR TITLE
Mtos cache in ram to boost performance

### DIFF
--- a/API.md
+++ b/API.md
@@ -207,7 +207,8 @@ Can be used for non-data and/or system tasks. For usual data store please use th
 - `bdev:get_hard_disk()` hdd store - a table with all app-related storage partitions, if hard disk capatibility exists
 - `bdev:get_removable_disk()` removable data object (drive)
 - `bdev:get_cloud_disk(storage_name)` - Get named cloud storage
-- `bdev:sync()` - Write/store all opened and maybe changed data
+- `bdev:sync()` - Write/store all opened and maybe changed data (cached)
+- `bdev:sync_cloud()` - Write/store all opened and maybe changed data in cloud
 
 ### Storage methods
 - `get_boot_disk()` - Check which device can be booted. possible return value is "hdd" or "removable"

--- a/apps/removable_app.lua
+++ b/apps/removable_app.lua
@@ -58,5 +58,6 @@ laptop.register_app("removable", {
 			end
 		end
 		mtos.bdev:sync()
+		laptop.mtos_cache:free(mtos.pos)
 	end,
 })

--- a/apps/removable_app.lua
+++ b/apps/removable_app.lua
@@ -57,7 +57,6 @@ laptop.register_app("removable", {
 				mtos:power_on() --reboot
 			end
 		end
-		mtos.bdev:sync()
-		laptop.mtos_cache:free(mtos.pos)
+		laptop.mtos_cache:sync_and_free(mtos)
 	end,
 })

--- a/block_devices.lua
+++ b/block_devices.lua
@@ -77,8 +77,8 @@ function bdev:get_removable_disk(removable_type)
 			if not self.stack then
 				return false
 			end
-			local drop_pos = table.copy(self.bdev.os.pos)
-			drop_pos = { x=drop_pos.x+math.random()*2-1, y=drop_pos.y,z=drop_pos.z+math.random()*2-1 }
+			local p = self.bdev.os.pos
+			local drop_pos = { x=p.x+math.random()*2-1, y=p.y,z=p.z+math.random()*2-1 }
 			minetest.item_drop(self.stack, nil, drop_pos)
 			self.stack = nil
 			return true
@@ -192,7 +192,10 @@ end
 
 -- Get handler
 function laptop.get_bdev_handler(mtos)
-	local bdevobj = table.copy(bdev)
+	local bdevobj = {}
+	for k,v in pairs(bdev) do
+		bdevobj[k] = v
+	end
 	bdevobj.os = mtos
 	return bdevobj
 end

--- a/block_devices.lua
+++ b/block_devices.lua
@@ -178,7 +178,10 @@ function bdev:sync()
 		end
 		self.removable_disk.inv:set_stack("main", 1, self.removable_disk.stack)
 	end
+end
 
+-- Save all data if used
+function bdev:sync_cloud()
 	-- Modmeta (Cloud)
 	if self.cloud_disk then
 		for store, value in pairs(self.cloud_disk) do

--- a/block_devices.lua
+++ b/block_devices.lua
@@ -21,8 +21,8 @@ function bdev:get_ram_disk()
 end
 
 function bdev:free_ram_disk()
-	self.os.meta:set_string('laptop_ram','')
-	self.ram_disk = nil
+	self.ram_disk = {}
+	self:sync()
 end
 
 
@@ -47,7 +47,7 @@ function bdev:get_removable_disk(removable_type)
 		function data:reload(stack)
 			-- self.inv unchanged
 			-- self.rtype unchanged (assumption
-			stack = stack or data.inv:get_stack("main", 1)
+			stack = stack or self.inv:get_stack("main", 1)
 			if stack then
 				local def = stack:get_definition()
 				if def and def.name ~= "" then

--- a/hardware_fw.lua
+++ b/hardware_fw.lua
@@ -36,8 +36,7 @@ local function on_punch(pos, node, puncher)
 		puncher:set_wielded_item(slot.stack)
 		-- reload OS
 		slot:reload(punch_item)
-		mtos.bdev:sync()
-		laptop.mtos_cache:free(pos)
+		laptop.mtos_cache:sync_and_free(mtos)
 		for k,v in pairs(laptop.os_get(mtos.pos)) do
 			mtos[k] = v
 		end

--- a/hardware_fw.lua
+++ b/hardware_fw.lua
@@ -2,6 +2,7 @@
 laptop.node_config = {}
 
 local function on_construct(pos)
+	laptop.mtos_cache:free(pos)
 	local mtos = laptop.os_get(pos)
 	local node = minetest.get_node(pos)
 	local hwdef = laptop.node_config[node.name]
@@ -13,6 +14,10 @@ local function on_construct(pos)
 	else
 		mtos:power_off()
 	end
+end
+
+local function after_destruct(pos, oldnode)
+	laptop.mtos_cache:free(pos)
 end
 
 local function on_punch(pos, node, puncher)
@@ -36,6 +41,7 @@ local function on_punch(pos, node, puncher)
 		-- reload OS
 		slot:reload(punch_item)
 		mtos.bdev:sync()
+		laptop.mtos_cache:free(pos)
 		for k,v in pairs(laptop.os_get(mtos.pos)) do
 			mtos[k] = v
 		end
@@ -186,6 +192,7 @@ function laptop.register_hardware(name, hwdef)
 --		def.preserve_metadata = preserve_metadata TODO: if MT-0.5 stable
 		def.on_punch = on_punch
 		def.on_construct = on_construct
+		def.after_destruct = after_destruct
 		def.on_receive_fields = on_receive_fields
 		def.allow_metadata_inventory_move = allow_metadata_inventory_move
 		def.allow_metadata_inventory_put = allow_metadata_inventory_put

--- a/mtos.lua
+++ b/mtos.lua
@@ -208,10 +208,12 @@ function os_class:set_theme(theme)
 end
 
 function os_class:get_os_attr()
-	local os_attr = table.copy(laptop.os_version_attr.default)
-	if self.hwdef.os_version then
-		os_attr = table.copy(laptop.os_version_attr[self.hwdef.os_version])
+	local os_attr = {}
+	local os_version = self.hwdef.os_version or 'default'
+	for k, v in pairs(laptop.os_version_attr[os_version]) do
+		os_attr[k] = v
 	end
+
 	os_attr.tty_style = self.hwdef.tty_style or os_attr.tty_style
 	if self.hwdef.tty_monochrome ~= nil then
 		os_attr.tty_monochrome = self.hwdef.tty_monochrome
@@ -278,7 +280,10 @@ function os_class:get_app(name)
 	if not template then
 		return
 	end
-	local app = setmetatable(table.copy(template), laptop.class_lib.app)
+	local app = setmetatable({}, laptop.class_lib.app)
+	for k,v in pairs(template) do
+		app[k] = v
+	end
 	app.name = name
 	app.os = self
 	return app

--- a/themes.lua
+++ b/themes.lua
@@ -111,8 +111,11 @@ end
 
 
 function laptop.get_theme(theme_name)
-	local self = setmetatable(table.copy(laptop.themes.default), theme_class)
 	theme_name = theme_name or "Freedom"
+	local self = setmetatable({}, theme_class)
+	for k, v in pairs(laptop.themes.default) do
+		self[k] = v
+	end
 	if theme_name and laptop.themes[theme_name] then
 		for k,v in pairs(laptop.themes[theme_name]) do
 			self[k] = v


### PR DESCRIPTION
Before this change for each action the  the nodemeta was read and the "Operating system" object restored. After the action processing the nodemeta was saved to node and objec gets lost.

Now an Lua-table is used to cache the "Operating system"  instances to avoid unnecessary reads and wirtes to nodemeta. For some operations the full sync is forced (like inserting disk) but usual the "Operating system" instance is cached till 5 seconds not used.

The most noticable performance boost is in tetris app because the game requests the OS 3x per second

The drawback is in case the server crashes maybe some changes are not stored.

@Gerold55 @Grizzly-Adam @apachano please thest the changes intensive before we can merge them