### PR TITLE
hanging tetris if laptop was disabled during …

### DIFF
--- a/app_fw.lua
+++ b/app_fw.lua
@@ -49,11 +49,10 @@ end
 
 -- Back to previous app in stack
 function app_class:back_app(fields, sender)
-	self.os.sysram.current_app = self.os:appstack_pop()
+	self.os:set_app('<pop>', sender, fields)
 	if fields then
 		self.os:pass_to_app('receive_fields_func', true, sender, fields)
 	end
-	self.os:set_app(self.os.sysram.current_app)
 end
 
 -- Exit current app and back to launcher


### PR DESCRIPTION
Found a bug, the timer was not restored proper if tetris game was running and the laptop was deactivated / resumed (core laptop)
The reason was the timer was not saved/restored on stack pop that is used to come back from 'os:power_off' app.
Fixed now